### PR TITLE
[Feature] H2 데이터베이스 연결 - TCP 서버 모드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,17 @@ repositories {
 dependencies {
     // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // H2 database
+    implementation 'com.h2database:h2'
 
     // Jsch ( Java Secure Channel, SSH 터널링을 위한 라이브러리 )
     implementation 'com.jcraft:jsch:0.1.55'
@@ -42,7 +47,6 @@ dependencies {
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=BEE-homepage-backend

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,11 +2,17 @@ spring:
   application:
     name: BEE-homepage-backend
 
+#  datasource:
+#    url: ${AWS_MYSQL_SERVER_URL}
+#    username: ${AWS_MYSQL_SERVER_USERNAME}
+#    password: ${AWS_MYSQL_SERVER_PASSWORD}
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+
   datasource:
-    url: ${AWS_MYSQL_SERVER_URL}
-    username: ${AWS_MYSQL_SERVER_USERNAME}
-    password: ${AWS_MYSQL_SERVER_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:h2:tcp://localhost/~/beeTest
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
 
   jpa:
     hibernate:


### PR DESCRIPTION
### 작업 내용
- H2 데이터베이스를 TCP 서버 모드로 연결하도록 설정
- `application.yml`에 데이터베이스 URL, 드라이버, 사용자 정보 추가
- H2 콘솔 접속을 위한 설정 변경

### 작업 이유
- 로컬 개발 환경에서 빠르게 사용할 수 있도록 H2 데이터베이스를 설정
- TCP 서버 모드로 연결하여 다양한 개발 환경에서 접근 가능하도록 설정

### 테스트
- H2 콘솔 접속을 통해 데이터베이스 연결 확인: http://localhost:8082